### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10',
-                         'pypy3.6', 'pypy3.7', 'pypy3.8', 'pypy3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10',
+                         'pypy3.7', 'pypy3.8', 'pypy3.9']
     steps:
       - name: Clone Repository (Latest)
         uses: actions/checkout@v3

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,16 +7,26 @@ exclude =
 
 # Things to ignore:
 extend-ignore =
-    C101, # C101 - Coding magic comment not found
-    C407, # C407 - Unnecessary list comprehension - 'X' can take a generator.
-    C812, # C812 - missing trailing comma. Black figures it out.
-    C815, # C815 - missing trailing comma in Python 3.5+. Black figures it out.
+    # C101 - Coding magic comment not found
+    C101,
+    # C407 - Unnecessary list comprehension - 'X' can take a generator.
+    C407,
+    # C812 - missing trailing comma. Black figures it out.
+    C812,
+    # C815 - missing trailing comma in Python 3.5+. Black figures it out.
+    C815,
     D,
-    E203, # E203 - Whitespace before ':'. Required by black.
-    E501, # E501 - Line too long. Black will fold normal source lines.
-    Q000, # Q000 - Remove bad quotes. Black uses double quotes.
-    P101,  # P101 - format string does contain unindexed parameters
-    RST304, # RST304 - Unknown interpreted text role "func"/"mod". Sphinx uses these for links.
-    TAE002, # TAE002 - too complex annotation
+    # E203 - Whitespace before ':'. Required by black.
+    E203,
+    # E501 - Line too long. Black will fold normal source lines.
+    E501,
+    # Q000 - Remove bad quotes. Black uses double quotes.
+    Q000,
+    # P101 - format string does contain unindexed parameters
+    P101,
+    # RST304 - Unknown interpreted text role "func"/"mod". Sphinx uses these for links.
+    RST304,
+    # TAE002 - too complex annotation
+    TAE002,
     WPS,
     DAR,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
@@ -35,6 +34,6 @@ if __name__ == "__main__":
         package_data={"iso8583": ["py.typed"]},
         zip_safe=False,
         classifiers=classifiers,
-        python_requires=">=3.6",
+        python_requires=">=3.7",
         keywords="iso8583 8583 banking protocol library",
     )


### PR DESCRIPTION
Python 3.6 reached end-of-life on Dec 12, 2021.